### PR TITLE
biapy v3.6.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://files.pythonhosted.org/packages/source/b/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c8ef5398de30dd690cd7db25c263f972f802ff1319573c1917b9fd726d73b43d
+  lde44a26b1423a04b6dbf55e0c2ecdc545c8b34394c787bc22cb876924a76fb
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "biapy" %}
-{% set version = "3.6.3" %}
+{% set version = "3.6.4" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -13,7 +13,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: pip install . --no-deps --no-build-isolation
   entry_points:
     - biapy = biapy:main
 
@@ -53,7 +53,6 @@ test:
     - biapy
   commands:
     - pip check
-    - biapy --help
   requires:
     - python {{ python_min }}
     - pip


### PR DESCRIPTION
Automated bump to 3.6.4 after GitHub Release.\n\n- Recipe copied from project: `biapy/utils/env/conda_forge_meta.yaml`\n- Version and sha256 updated from PyPI sdist.