### PR TITLE
biapy v3.6.5

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -7,4 +7,4 @@ channel_targets:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 python_min:
-- '3.9'
+- '3.10'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About biapy-feedstock
 =====================
 
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/biapy-feedstock/blob/main/LICENSE.txt)
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/feedstock-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/BiaPyX/BiaPy
 
@@ -15,8 +15,8 @@ Current build status
 
 <table><tr><td>All platforms:</td>
     <td>
-      <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26227&branchName=main">
-        <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/biapy-feedstock?branchName=main">
+      <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=None&branchName=main">
+        <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/feedstock-feedstock?branchName=main">
       </a>
     </td>
   </tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "biapy" %}
-{% set version = "3.6.3" %}
+{% set version = "3.6.5" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -13,7 +13,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: pip install . --no-deps --no-build-isolation
   entry_points:
     - biapy = biapy:main
 
@@ -53,7 +53,6 @@ test:
     - biapy
   commands:
     - pip check
-    - biapy --help
   requires:
     - python {{ python_min }}
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,8 +8,7 @@ package:
 
 source:
   url: https://files.pythonhosted.org/packages/source/b/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c8ef5398de30dd690cd7db25c263f972f802ff1319573c1917b9fd726d73b43d
-
+  sha256: a12d12a246cdc9bd91be03e84c6751725fe804ce8ed65efd458419f5132e92ca
 build:
   noarch: python
   number: 0


### PR DESCRIPTION
Automated bump to 3.6.5 after GitHub Release. Recipe copied from project: `biapy/utils/env/conda_forge_meta.yaml` . Version and sha256 updated from PyPI sdist.