### PR TITLE
biapy v3.6.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,8 +8,7 @@ package:
 
 source:
   url: https://files.pythonhosted.org/packages/source/b/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c8ef5398de30dd690cd7db25c263f972f802ff1319573c1917b9fd726d73b43d
-
+  sha256: d82a21541453398779616992fdacf1afed2dda7e12cb4d1ea771e5e00ecfbcec
 build:
   noarch: python
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "biapy" %}
-{% set version = "3.6.6" %}
+{% set version = "3.6.7" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -8,7 +8,8 @@ package:
 
 source:
   url: https://files.pythonhosted.org/packages/source/b/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 154334a887b9634454bf6406f48995bf10c32ffe3263286bc19f8d7a50af3fa5
+  sha256: c8ef5398de30dd690cd7db25c263f972f802ff1319573c1917b9fd726d73b43d
+
 build:
   noarch: python
   number: 0


### PR DESCRIPTION
Automated bump to 3.6.7 after GitHub Release. Recipe copied from project: `biapy/utils/env/conda_forge_meta.yaml`. Version and sha256 updated from PyPI sdist.