### PR TITLE
biapy v3.6.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About biapy-feedstock
 =====================
 
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/biapy-feedstock/blob/main/LICENSE.txt)
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/feedstock-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/BiaPyX/BiaPy
 
@@ -15,8 +15,8 @@ Current build status
 
 <table><tr><td>All platforms:</td>
     <td>
-      <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26227&branchName=main">
-        <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/biapy-feedstock?branchName=main">
+      <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=None&branchName=main">
+        <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/feedstock-feedstock?branchName=main">
       </a>
     </td>
   </tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,8 +8,7 @@ package:
 
 source:
   url: https://files.pythonhosted.org/packages/source/b/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c8ef5398de30dd690cd7db25c263f972f802ff1319573c1917b9fd726d73b43d
-
+  sha256: 3f1e3bf51dd1fb82d84f4aced31a657688903ac041e86ac74af32ee784f34884
 build:
   noarch: python
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "biapy" %}
-{% set version = "3.6.7" %}
+{% set version = "3.6.8" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -8,7 +8,8 @@ package:
 
 source:
   url: https://files.pythonhosted.org/packages/source/b/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d82a21541453398779616992fdacf1afed2dda7e12cb4d1ea771e5e00ecfbcec
+  sha256: c8ef5398de30dd690cd7db25c263f972f802ff1319573c1917b9fd726d73b43d
+
 build:
   noarch: python
   number: 0
@@ -23,7 +24,7 @@ requirements:
     - setuptools
   run:
     - python >={{ python_min }}
-    - pytorch >=2.4
+    - pytorch >=2.9
     - timm ==1.0.14
     - pytorch-msssim
     - torchmetrics >=1.4,<1.5


### PR DESCRIPTION
Automated bump to 3.6.8 after GitHub Release. Recipe copied from project: `biapy/utils/env/conda_forge_meta.yaml`. Version and sha256 updated from PyPI sdist.